### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { MethodNotAllowedError, InternalServerError } from './errors.js';
+
+function onNoMatchHandler(req, res) {
+  const publicErrorObject = new MethodNotAllowedError();
+  res.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, req, res) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  res.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from 'pg';
+import { ServiceError } from './errors.js';
 
 async function query(queryObject) {
   let client;
@@ -8,7 +9,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.error(error);
+    const serviceErrorObject = new ServiceError({
+      message: 'Error na conexão com o banco ou na query',
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,17 +1,55 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super('Um erro interno não esperado aconteceu.', {
       cause,
     });
     this.name = 'InternalServerError';
     this.action = 'Entre em contato com o suporte';
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
   }
 
-  toJson() {
+  toJSON() {
     return {
       name: this.name,
-      messagem: this.message,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || 'Serviço indisponível no momento.', {
+      cause,
+    });
+    this.name = 'InternalServerError';
+    this.action = 'Verifique se o serviço está disponível.';
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super('Método não permitido para este endpoint.');
+    this.name = 'MethodNotAllowedError';
+    this.action = 'Verifique se o método HTTP enviado é válido para este endpoint.';
+    this.statusCode = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
       action: this.action,
       status_code: this.statusCode,
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.5.0",
         "dotenv-expand": "12.0.2",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2115,6 +2116,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -9142,6 +9149,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10155,6 +10175,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "16.5.0",
     "dotenv-expand": "12.0.2",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,52 +1,60 @@
+import { createRouter } from 'next-connect';
 import migrationRunner from 'node-pg-migrate';
 import { resolve } from 'node:path';
 import database from 'infra/database.js';
+import controller from 'infra/controller.js';
 
-export default async function migrations(req, res) {
-  const allowedMethods = ['GET', 'POST'];
-  if (!allowedMethods.includes(req.method)) {
-    res.status(405).json({
-      error: `Method ${req.method} not allowed`,
-    });
-  }
+const router = createRouter();
 
+router.get(getHandler);
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+const migrateDefaultOptions = {
+  dryRun: true,
+  dir: resolve('infra', 'migrations'),
+  direction: 'up',
+  verbose: true,
+  migrationsTable: 'pgmigrations',
+};
+
+async function getHandler(req, res) {
   let dbClient;
 
   try {
     dbClient = await database.getNewClient();
 
-    const defaultMigrationsOptions = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve('infra', 'migrations'),
-      direction: 'up',
-      verbose: true,
-      migrationsTable: 'pgmigrations',
-    };
-
-    if (req.method === 'GET') {
-      const pendingMigrations = await migrationRunner(defaultMigrationsOptions);
-      await dbClient.end();
-      return res.status(200).json(pendingMigrations);
-    }
-
-    if (req.method === 'POST') {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationsOptions,
-        dryRun: false,
-      });
-      await dbClient.end();
-
-      if (migratedMigrations.length > 0) {
-        return res.status(201).json(migratedMigrations);
-      }
-
-      return res.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
-  } finally {
+    const pendingMigrations = await migrationRunner({
+      ...migrateDefaultOptions,
+      dbClient,
+    });
     await dbClient.end();
+    return res.status(200).json(pendingMigrations);
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+async function postHandler(req, res) {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...migrateDefaultOptions,
+      dbClient,
+      dryRun: false,
+    });
+    await dbClient.end();
+
+    if (migratedMigrations.length > 0) {
+      return res.status(201).json(migratedMigrations);
+    }
+
+    return res.status(200).json(migratedMigrations);
+  } finally {
+    await dbClient?.end();
   }
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,40 +1,36 @@
+import { createRouter } from 'next-connect';
 import database from 'infra/database.js';
-import { InternalServerError } from 'infra/errors.js';
+import controller from 'infra/controller.js';
 
-export default async function status(req, res) {
-  try {
-    const updatedAt = new Date().toISOString();
-    const dbVersionResult = await database.query('SHOW server_version;');
-    const dbVersionValue = dbVersionResult.rows[0].server_version;
-    const dbMaxConnectionsResult = await database.query('SHOW max_connections;');
+const router = createRouter();
 
-    const dbName = process.env.POSTGRES_DB;
-    const dbMaxConnectionsValue = dbMaxConnectionsResult.rows[0].max_connections;
-    const dbOpenedConnectionsResult = await database.query({
-      text: 'SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;',
-      values: [dbName],
-    });
-    const dbOpenedConnectionsValue = dbOpenedConnectionsResult.rows[0].count;
+router.get(getHandler);
 
-    res.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          //status: null,
-          max_connections: parseInt(dbMaxConnectionsValue),
-          opened_connections: dbOpenedConnectionsValue,
-          version: dbVersionValue,
-        },
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(req, res) {
+  const updatedAt = new Date().toISOString();
+  const dbVersionResult = await database.query('SHOW server_version;');
+  const dbVersionValue = dbVersionResult.rows[0].server_version;
+  const dbMaxConnectionsResult = await database.query('SHOW max_connections;');
+
+  const dbName = process.env.POSTGRES_DB;
+  const dbMaxConnectionsValue = dbMaxConnectionsResult.rows[0].max_connections;
+  const dbOpenedConnectionsResult = await database.query({
+    text: 'SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;',
+    values: [dbName],
+  });
+  const dbOpenedConnectionsValue = dbOpenedConnectionsResult.rows[0].count;
+
+  res.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        //status: null,
+        max_connections: parseInt(dbMaxConnectionsValue),
+        opened_connections: dbOpenedConnectionsValue,
+        version: dbVersionValue,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log('\n Erro dentro do catch do controller:');
-    console.error(publicErrorObject);
-
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
+    },
+  });
 }

--- a/tests/integration/ap1/v1/status/post.test.js
+++ b/tests/integration/ap1/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe('POST /api/v1/status', () => {
+  describe('Anonymous user', () => {
+    test('Retrieving current system status', async () => {
+      const response = await fetch('http://localhost:3000/api/v1/status', {
+        method: 'POST',
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: 'MethodNotAllowedError',
+        message: 'Método não permitido para este endpoint.',
+        action: 'Verifique se o método HTTP enviado é válido para este endpoint.',
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints /migrations e /status.
2. Adiciona 2 novos erros customizados: MethodNotAllowedError e ServiceError.
3. Faz o InternalServerError aceitar injeção do statusCode.